### PR TITLE
Disposable message handler

### DIFF
--- a/src/Elders.Cronus.Tests/Elders.Cronus.Tests.csproj
+++ b/src/Elders.Cronus.Tests/Elders.Cronus.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="IocContainer\When_resolve_scoped_component_with_specific_type.cs" />
     <Compile Include="IocContainer\When_resolve_two_scoped_components_with_common_interface.cs" />
     <Compile Include="MessageStreaming\Models.cs" />
+    <Compile Include="MessageStreaming\When_message_handler_implements__IDisposable__.cs" />
     <Compile Include="MessageStreaming\When_subscription_subscribes_to__MessageStream__more_than_once.cs" />
     <Compile Include="MessageStreaming\When__MessageStream__has_subscription_which_does_not_care_about_current_feed_messages.cs" />
     <Compile Include="MessageStreaming\When__MessageStream__has_subscription_which_fails_to_handle_a_message.cs" />

--- a/src/Elders.Cronus.Tests/MessageStreaming/When_message_handler_implements__IDisposable__.cs
+++ b/src/Elders.Cronus.Tests/MessageStreaming/When_message_handler_implements__IDisposable__.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using Elders.Cronus.DomainModeling;
+using Elders.Cronus.MessageProcessing;
+using Elders.Cronus.Tests.TestModel;
+using Machine.Specifications;
+
+namespace Elders.Cronus.Tests.MessageStreaming
+{
+    [Subject("")]
+    public class When_message_handler_implements__IDisposable__
+    {
+        Establish context = () =>
+            {
+                handlerFacotry = new DisposableHandlerFactory();
+                messageStream = new MessageProcessor("test");
+                var subscription = new TestSubscription(typeof(CalculatorNumber1), handlerFacotry);
+
+                messages = new List<TransportMessage>();
+                messages.Add(new TransportMessage(new Message(new CalculatorNumber1(1))));
+                messageStream.Subscribe(subscription);
+            };
+
+        Because of = () =>
+            {
+                feedResult = messageStream.Feed(messages);
+            };
+
+        It should_dispose_handler_resources_if_possible = () => (handlerFacotry.State.Current as DisposableHandlerFactory.DisposableHandler).IsDisposed.ShouldBeTrue();
+
+        static IFeedResult feedResult;
+        static MessageProcessor messageStream;
+        static List<TransportMessage> messages;
+        static DisposableHandlerFactory handlerFacotry;
+    }
+
+    public class DisposableHandlerFactory : IHandlerFactory
+    {
+        public Type MessageHandlerType { get { return typeof(StandardCalculatorAddHandler); } }
+
+        public IHandlerInstance State { get; set; }
+
+        public IHandlerInstance Create()
+        {
+            State = new DefaultHandlerInstance(new DisposableHandler());
+            return State;
+        }
+
+        public class DisposableHandler : IDisposable
+        {
+            public bool IsDisposed { get; set; }
+
+            public void Handle(CalculatorNumber1 @event) { }
+
+            public void Dispose() { IsDisposed = true; }
+        }
+    }
+}

--- a/src/Elders.Cronus.Tests/MessageStreaming/When_message_handler_implements__IDisposable__.cs
+++ b/src/Elders.Cronus.Tests/MessageStreaming/When_message_handler_implements__IDisposable__.cs
@@ -36,7 +36,7 @@ namespace Elders.Cronus.Tests.MessageStreaming
 
     public class DisposableHandlerFactory : IHandlerFactory
     {
-        public Type MessageHandlerType { get { return typeof(StandardCalculatorAddHandler); } }
+        public Type MessageHandlerType { get { return typeof(DisposableHandler); } }
 
         public IHandlerInstance State { get; set; }
 

--- a/src/Elders.Cronus.Tests/TestModel/TestSubscription.cs
+++ b/src/Elders.Cronus.Tests/TestModel/TestSubscription.cs
@@ -16,8 +16,11 @@ namespace Elders.Cronus.Tests.TestModel
 
         protected override void InternalOnNext(Message value)
         {
-            object handler = Factory.Create();
-            ((dynamic)handler).Handle((dynamic)value.Payload);
+            using (var handlerInstance = Factory.Create())
+            {
+                dynamic handler = handlerInstance.Current;
+                handler.Handle((dynamic)value.Payload);
+            }
         }
     }
 }

--- a/src/Elders.Cronus/Elders.Cronus.csproj
+++ b/src/Elders.Cronus/Elders.Cronus.csproj
@@ -107,6 +107,7 @@
     <Compile Include="IocContainer\MappingKey.cs" />
     <Compile Include="MessageProcessing\FeedResultExtentions.cs" />
     <Compile Include="MessageProcessing\IHandlerFactory.cs" />
+    <Compile Include="MessageProcessing\IHandlerInstance.cs" />
     <Compile Include="MessageProcessing\MessageProcessor.cs" />
     <Compile Include="MessageProcessing\IFeedResult.cs" />
     <Compile Include="MessageProcessing\MessageProcessorSubscription.cs" />

--- a/src/Elders.Cronus/MessageProcessing/IHandlerFactory.cs
+++ b/src/Elders.Cronus/MessageProcessing/IHandlerFactory.cs
@@ -5,12 +5,12 @@ namespace Elders.Cronus.MessageProcessing
     public interface IHandlerFactory
     {
         Type MessageHandlerType { get; }
-        object Create();
+        IHandlerInstance Create();
     }
 
     public class DefaultHandlerFactory : IHandlerFactory
     {
-        private readonly Func<Type, object> handlerFctory;
+        readonly Func<Type, object> handlerFctory;
 
         public DefaultHandlerFactory(Type messageHandlerType, Func<Type, object> handlerFactory)
         {
@@ -20,9 +20,9 @@ namespace Elders.Cronus.MessageProcessing
 
         public Type MessageHandlerType { get; private set; }
 
-        public object Create()
+        public IHandlerInstance Create()
         {
-            return handlerFctory(MessageHandlerType);
+            return new DefaultHandlerInstance(handlerFctory(MessageHandlerType));
         }
     }
 }

--- a/src/Elders.Cronus/MessageProcessing/IHandlerInstance.cs
+++ b/src/Elders.Cronus/MessageProcessing/IHandlerInstance.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Elders.Cronus.MessageProcessing
+{
+    public interface IHandlerInstance : IDisposable
+    {
+        object Current { get; }
+    }
+
+    public class DefaultHandlerInstance : IHandlerInstance
+    {
+        public DefaultHandlerInstance(object instance)
+        {
+            Current = instance;
+        }
+
+        public object Current { get; set; }
+
+        public void Dispose()
+        {
+            var disposeMe = Current as IDisposable;
+            if (ReferenceEquals(null, disposeMe) == false)
+                disposeMe.Dispose();
+        }
+    }
+}

--- a/src/Elders.Cronus/MessageProcessing/MessageProcessorSubscription.cs
+++ b/src/Elders.Cronus/MessageProcessing/MessageProcessorSubscription.cs
@@ -97,10 +97,11 @@ namespace Elders.Cronus.MessageProcessing
 
         protected override void InternalOnNext(Message value)
         {
-            dynamic handler = handlerFactory
-                .Create()
-                .AssignPropertySafely<IAggregateRootApplicationService>(x => x.Repository = aggregateRepository);
-            handler.Handle((dynamic)value.Payload);
+            using (var handlerInstance = handlerFactory.Create())
+            {
+                dynamic handler = handlerInstance.Current.AssignPropertySafely<IAggregateRootApplicationService>(x => x.Repository = aggregateRepository);
+                handler.Handle((dynamic)value.Payload);
+            }
         }
 
         class RepositoryProxy : IAggregateRepository
@@ -165,8 +166,11 @@ namespace Elders.Cronus.MessageProcessing
 
         protected override void InternalOnNext(Message value)
         {
-            dynamic handler = handlerFactory.Create();
-            handler.Handle((dynamic)value.Payload);
+            using (var handlerInstance = handlerFactory.Create())
+            {
+                dynamic handler = handlerInstance.Current;
+                handler.Handle((dynamic)value.Payload);
+            }
         }
     }
 
@@ -184,10 +188,11 @@ namespace Elders.Cronus.MessageProcessing
 
         protected override void InternalOnNext(Message value)
         {
-            dynamic handler = handlerFactory
-                .Create()
-                .AssignPropertySafely<IPort>(x => x.CommandPublisher = commandPublisher); ;
-            handler.Handle((dynamic)value.Payload);
+            using (var handlerInstance = handlerFactory.Create())
+            {
+                dynamic handler = handlerInstance.Current.AssignPropertySafely<IPort>(x => x.CommandPublisher = commandPublisher);
+                handler.Handle((dynamic)value.Payload);
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes #78 by making possible to dispose resources on a handler level when a message is handled successfully. This is similar to the hooks idea because the final goal is still the same. We just provide a mechanism a client code to hook into the execution pipeline and do some magic.