### PR TITLE
Case sensitive assembly loader for linux

### DIFF
--- a/src/Elders.Cronus/Cronus.rn.md
+++ b/src/Elders.Cronus/Cronus.rn.md
@@ -1,3 +1,7 @@
+#### 5.2.0-beta0006 - 21.12.2018
+* Fixed loading assemblies on linux since its case sensitive.
+* Fixed a SingleOrDefault blowup when an Assembly is loaded twice - for some reason, when using xUnit, xunit is loaded twice. 
+
 #### 5.2.0-beta0005 - 19.12.2018
 * Adds InMemory implementations for ILock and Publisher
 

--- a/src/Elders.Cronus/Hosting/AssemblyLoader.cs
+++ b/src/Elders.Cronus/Hosting/AssemblyLoader.cs
@@ -31,15 +31,16 @@ namespace Elders.Cronus
             loadAssembliesLog.AppendLine($"Try loading assemblies from directory: {directoryWithAssemblies}");
             loadAssembliesLog.AppendLine("Some assemblies will not be loaded because they are not managed which is fine and we output them bellow if any for completeness.");
 
-            var files = directoryWithAssemblies.GetFiles(new[] { "*.exe", "*.dll" }).Select(filepath => filepath.ToLower());
+            var files = directoryWithAssemblies.GetFiles(new[] { "*.exe", "*.dll" });
             foreach (var assemblyFile in files)
             {
-                if (wildcards.Any(x => assemblyFile.Contains(x))) continue;
-                if (excludedAssemblies.Any(x => assemblyFile.EndsWith(x))) continue;
+                var lowerAssemblyFile = assemblyFile.ToLower();
+                if (wildcards.Any(x => lowerAssemblyFile.Contains(x))) continue;
+                if (excludedAssemblies.Any(x => lowerAssemblyFile.EndsWith(x))) continue;
 
                 var assembly = AppDomain.CurrentDomain.GetAssemblies()
                     .Where(x => x.IsDynamic == false)
-                    .Where(x => x.Location.Equals(assemblyFile, StringComparison.OrdinalIgnoreCase) || x.CodeBase.Equals(assemblyFile, StringComparison.OrdinalIgnoreCase))
+                    .Where(x => x.Location.Equals(lowerAssemblyFile, StringComparison.OrdinalIgnoreCase) || x.CodeBase.Equals(lowerAssemblyFile, StringComparison.OrdinalIgnoreCase))
                     .SingleOrDefault();
 
                 if (assembly is null)

--- a/src/Elders.Cronus/Hosting/AssemblyLoader.cs
+++ b/src/Elders.Cronus/Hosting/AssemblyLoader.cs
@@ -38,10 +38,12 @@ namespace Elders.Cronus
                 if (wildcards.Any(x => lowerAssemblyFile.Contains(x))) continue;
                 if (excludedAssemblies.Any(x => lowerAssemblyFile.EndsWith(x))) continue;
 
-                var assembly = AppDomain.CurrentDomain.GetAssemblies()
+                var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies()
                     .Where(x => x.IsDynamic == false)
                     .Where(x => x.Location.Equals(lowerAssemblyFile, StringComparison.OrdinalIgnoreCase) || x.CodeBase.Equals(lowerAssemblyFile, StringComparison.OrdinalIgnoreCase))
-                    .SingleOrDefault();
+                    .ToList();
+
+                var assembly = loadedAssemblies.FirstOrDefault();
 
                 if (assembly is null)
                 {


### PR DESCRIPTION
xUnit is loaded twice (WTF?!?) and the SingleOrDefault() blows up....
```
AppDomain.CurrentDomain.GetAssemblies().Where(x=>x.FullName.ToLower().StartsWith("xunit.runner.visualstudio.dotnetcore.testadapter"))
{System.Linq.Enumerable.WhereArrayIterator<System.Reflection.Assembly>}
    [0]: {xunit.runner.visualstudio.dotnetcore.testadapter, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c}
    [1]: {xunit.runner.visualstudio.dotnetcore.testadapter, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c}
```
Assembly loading on linux is case sensitve:
```
root@6345099d4a25:/locus# dotnet elders.locus.api.dll

Unhandled Exception: System.TypeInitializationException: The type initializer for 'Elders.Cronus.AssemblyLoader' threw an exception. ---> System.IO.FileNotFoundException: Could not load file or assembly '/locus/system.interactive.async.dll'. The system cannot find the file specified.

   at System.Runtime.Loader.AssemblyLoadContext.LoadFromPath(IntPtr ptrNativeAssemblyLoadContext, String ilPath, String niPath, ObjectHandleOnStack retAssembly)
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String assemblyPath)
   at Elders.Cronus.AssemblyLoader.LoadAssembliesFromDirecotry(String directoryWithAssemblies)
   at Elders.Cronus.AssemblyLoader..cctor()
   --- End of inner exception stack trace ---
   at Elders.Cronus.Discoveries.DiscoveryBase1.Discover()
   at Elders.Cronus.CronusServiceCollectionExtensions.AddCronus(IServiceCollection services, CronusServicesProvider cronusServicesProvider)
   at Elders.Locus.Api.Startup.ConfigureServices(IServiceCollection services) in Z:\Projects\Elders\locus.backend\src\elders.locus.api\Startup.cs:line 24
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Hosting.ConventionBasedStartup.ConfigureServices(IServiceCollection services)
   at Microsoft.AspNetCore.Hosting.Internal.WebHost.EnsureApplicationServices()
   at Microsoft.AspNetCore.Hosting.Internal.WebHost.Initialize()
   at Microsoft.AspNetCore.Hosting.WebHostBuilder.Build()
   at Elders.Locus.Api.Program.Main(String[] args) in Z:\Projects\Elders\locus.backend\src\elders.locus.api\Program.cs:line 10
Aborted (core dumped)
root@6345099d4a25:/locus#
```