### PR TITLE
Change the way AssemblyLoader resolves the working directory

### DIFF
--- a/src/Elders.Cronus/Cronus.rn.md
+++ b/src/Elders.Cronus/Cronus.rn.md
@@ -1,3 +1,6 @@
+#### 6.0.0-beta0015 - 11.12.2019
+* Change the way AssemblyLoader resolves the working directory
+
 #### 6.0.0-beta0014 - 09.12.2019
 * Bumps to dotnet core 3.1
 * Code cleanup

--- a/src/Elders.Cronus/Hosting/AssemblyLoader.cs
+++ b/src/Elders.Cronus/Hosting/AssemblyLoader.cs
@@ -71,7 +71,17 @@ namespace Elders.Cronus
         {
             if (1 == Interlocked.Exchange(ref shouldLoadAssembliesFromDir, 0))
             {
+                // https://github.com/Elders/Cronus/issues/187
+                // Discoveries not working when tests are using TestHost on .net core 3.0 and up
+                // From.net core 3.0 the VS Test Platform(the one which is used from the Test Explorer of the VS) whenever uses a TestHost for
+                // making unit testing of an asp.net core project, instead of initiating the testing from a 'testhost.dll' which is in the root
+                // directory, it starts from a 'testhostx86.dll' which is located in the 'packages' folder.This breakes the discoveries as they
+                // depend the initial Assembly to always be situated in the root directory of the project.This prevents Cronus from working in
+                // such a situations.
+                // If you use MSTest(run dotnet test instead of 'dotnet vstest') everything works because it actually runs as previous
+                // (testhost.dll situated inside the correct directory)
                 string codeBase = AppDomain.CurrentDomain.BaseDirectory;
+                //string codeBase = Assembly.GetEntryAssembly().CodeBase;
                 UriBuilder uri = new UriBuilder(codeBase);
                 string path = Uri.UnescapeDataString(uri.Path);
                 var dir = Path.GetDirectoryName(path);

--- a/src/Elders.Cronus/Hosting/AssemblyLoader.cs
+++ b/src/Elders.Cronus/Hosting/AssemblyLoader.cs
@@ -71,7 +71,7 @@ namespace Elders.Cronus
         {
             if (1 == Interlocked.Exchange(ref shouldLoadAssembliesFromDir, 0))
             {
-                string codeBase = Assembly.GetEntryAssembly().CodeBase;
+                string codeBase = AppDomain.CurrentDomain.BaseDirectory;
                 UriBuilder uri = new UriBuilder(codeBase);
                 string path = Uri.UnescapeDataString(uri.Path);
                 var dir = Path.GetDirectoryName(path);


### PR DESCRIPTION
#187

we should discuss and walk again through all the dependency registration mechanism and the boostrap step of the Cronus. To quick fix running test through 'VS Test Platform' for now and give us more time to rethink it please review this fix