### PR TITLE
Register a type container with discovered commands

### DIFF
--- a/src/Elders.Cronus/Cronus.rn.md
+++ b/src/Elders.Cronus/Cronus.rn.md
@@ -1,3 +1,6 @@
+#### 6.0.0-beta0019 - 06.04.2020
+* Register a type container with discovered commands
+
 #### 6.0.0-beta0018 - 30.03.2020
 * Adds bounded context header when publishing a message
   

--- a/src/Elders.Cronus/Discoveries/CronusHostDiscovery.cs
+++ b/src/Elders.Cronus/Discoveries/CronusHostDiscovery.cs
@@ -24,8 +24,11 @@ namespace Elders.Cronus.Discoveries
 
             yield return new DiscoveredModel(typeof(BoundedContext), typeof(BoundedContext), ServiceLifetime.Transient);
 
-            var loadedTypes = context.Assemblies.Find<IEvent>().Where(type => type != typeof(EntityEvent));
-            yield return new DiscoveredModel(typeof(TypeContainer<IEvent>), new TypeContainer<IEvent>(loadedTypes));
+            var loadedCommands = context.Assemblies.Find<ICommand>();
+            yield return new DiscoveredModel(typeof(TypeContainer<ICommand>), new TypeContainer<ICommand>(loadedCommands));
+
+            var loadedEvents = context.Assemblies.Find<IEvent>().Where(type => type != typeof(EntityEvent));
+            yield return new DiscoveredModel(typeof(TypeContainer<IEvent>), new TypeContainer<IEvent>(loadedEvents));
         }
     }
 }


### PR DESCRIPTION
# Title
Register a type container with discovered commands

## Related Issue 
#150 

### Description
Find all `ICommand` implementations and register a `TypeContainer<ICommand>` with them

### Test Methods
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->