### PR TITLE
Gh 216

### DIFF
--- a/src/Elders.Cronus/Discoveries/InMemoryPublisherDiscovery.cs
+++ b/src/Elders.Cronus/Discoveries/InMemoryPublisherDiscovery.cs
@@ -18,6 +18,8 @@ namespace Elders.Cronus.Discoveries
             yield return new DiscoveredModel(typeof(ILock), typeof(InMemoryLockWithTTL), ServiceLifetime.Transient);
             yield return new DiscoveredModel(typeof(IPublisher<>), typeof(InMemoryPublisher<>), ServiceLifetime.Singleton);
             yield return new DiscoveredModel(typeof(IAggregateRootAtomicAction), typeof(InMemoryAggregateRootAtomicAction), ServiceLifetime.Transient);
+
+            yield return new DiscoveredModel(typeof(IConsumer<>), typeof(EmptyConsumer<>), ServiceLifetime.Singleton);
         }
     }
 }

--- a/src/Elders.Cronus/Hosting/CronusServiceCollectionExtensions.cs
+++ b/src/Elders.Cronus/Hosting/CronusServiceCollectionExtensions.cs
@@ -53,6 +53,7 @@ namespace Elders.Cronus
 
         internal static IServiceCollection AddCronusHostOptions(this IServiceCollection services)
         {
+            services.AddOptions();
             services.AddOptions<CronusHostOptions, CronusHostOptionsProvider>();
             services.AddOptions<BoundedContext, BoundedContextProvider>();
 

--- a/src/Elders.Cronus/IConsumer.cs
+++ b/src/Elders.Cronus/IConsumer.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace Elders.Cronus
 {
     public interface IConsumer<T>
@@ -7,8 +9,28 @@ namespace Elders.Cronus
         void Stop();
     }
 
-    interface IInMemoryConsumer<T> : IConsumer<T>
+    public class EmptyConsumer<T> : IConsumer<T>
     {
+        // Adds tracing once we have the logger in the IOC
+        //private readonly ILogger<EmptyConsumer<T>> log;
 
+        //public EmptyConsumer(ILogger<EmptyConsumer<T>> log)
+        //{
+        //    this.log = log;
+        //}
+
+
+        //public void Start() => log.LogTrace("Doing nothing.");
+
+        //public void Stop() => log.LogTrace("Doing nothing.");
+        public void Start()
+        {
+
+        }
+
+        public void Stop()
+        {
+
+        }
     }
 }


### PR DESCRIPTION
# Title
Allows pure InMemory startup without throwing an exception

## Related Issue 
fixes #216 

### Description
- Makes sure that the internal support registrations are added to the services.
- Registers an EmptyConsumer by default for the IConsumer<>. Other components such as RabbitMQ will have the responsibility to override this. #218 
- Adds EmptyConsumer type which does nothing
